### PR TITLE
Support for Private Browsing

### DIFF
--- a/data/js/IVPlus.js
+++ b/data/js/IVPlus.js
@@ -2,12 +2,8 @@
 let prefs;
 self.port.on('prefs', function(prefs_obj) {
     prefs = prefs_obj;
-    // If color preferences are not hex color codes, use the default values
-    color_pattern = /^#(?:[0-9a-f]{3}){1,2}$/i;
-    if(!color_pattern.test(prefs['bg_color'])) prefs['bg_color'] = '#222';
-    if(!color_pattern.test(prefs['light_color'])) prefs['light_color'] = '#f1f1f1';
     // Setting the preferred background color
-    $('body').css('background-color', prefs['bg_color']);
+    $('.ImgWrapper').css('background-color', prefs['bg_color']);
 
     if(!prefs['disable_toolbar']) {
 	// Adding necessary elements
@@ -193,10 +189,10 @@ function minimize() {
 
 function light_switch() {
     if(lights === 'off') {
-        $('body').css('background-color', prefs['light_color']);
+        $('.ImgWrapper').css('background-color', prefs['light_color']);
         lights = 'on';
     } else if(lights === 'on') {
-        $('body').css('background-color', prefs['bg_color']);
+        $('.ImgWrapper').css('background-color', prefs['bg_color']);
         lights = 'off';
     }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,10 +2,6 @@ const data = require('sdk/self').data;
 const { PageMod } = require('sdk/page-mod');
 const prefs = require("sdk/simple-prefs");
 
-/** Using prefList list temporarily till Bug 709382 gets fixed
-    Bug 709382 – require("simple-prefs").prefs should be iterable
-    https://bugzilla.mozilla.org/show_bug.cgi?id=709382
-**/
 const prefList = ['bg_color', 'light_color', 'disable_toolbar'];
 
 // Declaring the preferences object

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "description": "ImgViewerPlus(Image Viewer Plus) adds zoom, rotate and light switch capabilities with smooth animations to Firefox image viewer. It also makes background and light colors customizable.",
     "preferences": [
         {
-            "type": "string",
+            "type": "color",
             "name": "bg_color",
             "value": "#222",
             "title": "Background Color",
             "description": "Default: #222"
         },
         {
-            "type": "string",
+            "type": "color",
             "name": "light_color",
             "value": "#f1f1f1",
             "title": "Light Color",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "license": "MPL 2.0",
     "author": "Siavash Askari Nasr",
     "translators": ["Wang.H.K [zh-CN]"],
-    "version": "0.7.2",
+    "version": "0.7.3",
     "fullName": "ImgViewerPlus",
     "id": "jid1-XhgQ9TyZs7M16g",
     "description": "ImgViewerPlus(Image Viewer Plus) adds zoom, rotate and light switch capabilities with smooth animations to Firefox image viewer. It also makes background and light colors customizable.",
@@ -29,5 +29,6 @@
             "title": "Disable Toolbar",
             "description": "If you only want to use the keyboard shortcuts, check this option."
         }
-    ]
+    ],
+	"permissions": {"private-browsing": true}
 }


### PR DESCRIPTION
This pull request fixes some things that didn't work in newer versions of Firefox
- Adds the preference in `package.json` to allow the extension to work in Private Browsing mode.
- Also I updated the version to `0.7.3`
- Removed a comment about a resolved bug :)
- Changed the background color preference type to enter them as `color` instead of `strings` in the preferences dialog
- Changed the color to set the correct element as it didn't have effect on the body element.
